### PR TITLE
Adds mapping to send unspecified traffic to websvc

### DIFF
--- a/deploy/websvc/mappings.yaml
+++ b/deploy/websvc/mappings.yaml
@@ -11,3 +11,15 @@ spec:
   prefix: /
   service: "websvc.default:8080"
   resolver: endpoint
+---
+apiVersion: getambassador.io/v3alpha1
+kind:  Mapping
+metadata:
+  name:  websvc-catchall-mapping
+  labels:
+    app.kubernetes.io/name: websvc
+    app.kubernetes.io/instance: 0.1.0
+spec:
+  prefix: /
+  service: "websvc.default:8080"
+  resolver: endpoint


### PR DESCRIPTION
Right now if requests come in on hosts that we haven't specified in another mapping they'll get a 500 error. This mapping sends any traffic that doesn't match another mapping to the web service.